### PR TITLE
Lambda importer fails without change to zip

### DIFF
--- a/lambda_function/package-lambda-function.sh
+++ b/lambda_function/package-lambda-function.sh
@@ -18,6 +18,6 @@ touch $VIRTUAL_ENV/lib/python2.7/site-packages/snowflake/__init__.py
 # add all the contents of site-packages to the zip archive
 DIR=`pwd`
 cd $VIRTUAL_ENV/lib/python2.7/site-packages
-zip -r9 $DIR/lambda_function.zip *
+zip -r9 $DIR/lambda_function.zip .
 cd $VIRTUAL_ENV/lib64/python2.7/site-packages
-zip -r9 $DIR/lambda_function.zip *
+zip -r9 $DIR/lambda_function.zip .


### PR DESCRIPTION
Due to a change in one of the libs (cffi) the zip command that is currently in the example will no longer work. Result is lambda fails to execute with a no module import error.

Changing the zip command to use . instead of * allows it to get all the dirs and files properly